### PR TITLE
Fix audio reinitializing, press B to stop video

### DIFF
--- a/arm7/source/aac.cpp
+++ b/arm7/source/aac.cpp
@@ -90,6 +90,7 @@ void aac_reset()
         sAACInitialized = false;
     }
     sNextAudioBlock = 0;
+    sAudioBlockCount = 0;
     sAudioStarted = false;
     sAACInitialized = false;
 }


### PR DESCRIPTION
This fixes the audio not being fully reinitialized, makes it so you can press `B` to stop playing a video, and fixes some compiler warning in `main.cpp` (all but the variable/function isn't used ones)